### PR TITLE
Support string ports

### DIFF
--- a/tests/test_syslog.py
+++ b/tests/test_syslog.py
@@ -150,6 +150,7 @@ args = [
     # ((given address), given proto), (exp address), exp proto)
     ((('localhost', 514), 2), (('localhost', 514), 2)),
     ((('localhost', 514), None), (('localhost', 514), 2)),
+    ((('localhost', '514'), None), (('localhost', 514), 2)),
     ((('10.99.0.1', None), 1), (('10.99.0.1', 514), 1)),
     (('/dev/log', None), ('/dev/log', 2)),
 ]

--- a/ulogger/__init__.py
+++ b/ulogger/__init__.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import
 from ulogger.ulogger import setup_logging
 
 __author__ = 'Lynn Root'
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 __license__ = 'Apache 2.0'
 __email__ = 'lynn@spotify.com'
 __description__ = 'Micro logging library'

--- a/ulogger/syslog.py
+++ b/ulogger/syslog.py
@@ -79,10 +79,20 @@ class SyslogHandlerBuilder:
 
     def _get_address(self, address):
         if address:
-            if len(address) == 2:
-                if address[1] is None:
-                    return (address[0], logging.handlers.SYSLOG_UDP_PORT)
+            # python 2/3 compatibility
+            try:
+                basestring
+            except NameError:
+                basestring = str
+
+            if not isinstance(address, basestring):
+                if len(address) == 2:
+                    if address[1] is None:
+                        address = (address[0], logging.handlers.SYSLOG_UDP_PORT)
+                    else:
+                        address = (address[0], int(address[1]))
             return address
+
         address = {
             'default': '/dev/log',
             'darwin': '/var/run/syslog',


### PR DESCRIPTION
In developing [gordon](https://github.com/spotify/gordon), we encountered an [issue with ulogger configuration](https://github.com/spotify/gordon/pull/38/files#r197152699) where supplying a string port would fail when instantiating a syslog handler. This unforgivingly attempts to cast the string to an int.

Note to reviewers: this repo doesn't follow git flow or or release process with gordon (predates the writing of our contributors.rst file). This will make a release via Travis when tagged, so if it's approved, I'll tag it and push the tag to master.

cc @spotify/alf 