### PR TITLE
Fix httplib2 vulnerability by bumping

### DIFF
--- a/stackdriver-requirements.txt
+++ b/stackdriver-requirements.txt
@@ -9,7 +9,7 @@ google-cloud-logging==1.4.0
 google-gax==0.15.15
 googleapis-common-protos==1.5.3
 grpcio==1.7.0
-httplib2==0.10.3
+httplib2==0.18.0
 oauth2client==3.0.0
 ply==3.8
 proto-google-cloud-logging-v2==0.91.3


### PR DESCRIPTION
See https://github.com/advisories/GHSA-gg84-qgv9-w4pq