### PR TITLE
Exclude tests from package build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ def install_requires():
 # Project-specific constants
 #####
 NAME = 'ulogger'
-PACKAGES = find_packages(where='.')
+PACKAGES = find_packages(exclude=['tests*'])
 META_PATH = os.path.join(NAME, '__init__.py')
 KEYWORDS = ['logging']
 CLASSIFIERS = [


### PR DESCRIPTION
From this:

ulogger-3.6.9 [ 0 ] 27678 zephyr@zephyrs-mbp /Users/zephyr/spotify/gh/ulogger master *= $ python setup.py -n build
running build
running build_py
creating build
creating build/lib
creating build/lib/ulogger
copying ulogger/__init__.py -> build/lib/ulogger
copying ulogger/syslog.py -> build/lib/ulogger
copying ulogger/exceptions.py -> build/lib/ulogger
copying ulogger/ulogger.py -> build/lib/ulogger
copying ulogger/stackdriver.py -> build/lib/ulogger
creating build/lib/tests
copying tests/test_syslog.py -> build/lib/tests
copying tests/__init__.py -> build/lib/tests
copying tests/test_stackdriver.py -> build/lib/tests
copying tests/test_ulogger.py -> build/lib/tests

To this:

ulogger-3.6.9 [ 0 ] 27678 zephyr@zephyrs-mbp /Users/zephyr/spotify/gh/ulogger master= $ python setup.py -n build
running build
running build_py
creating build
creating build/lib
creating build/lib/ulogger
copying ulogger/__init__.py -> build/lib/ulogger
copying ulogger/syslog.py -> build/lib/ulogger
copying ulogger/exceptions.py -> build/lib/ulogger
copying ulogger/ulogger.py -> build/lib/ulogger
copying ulogger/stackdriver.py -> build/lib/ulogger